### PR TITLE
Set height and width of resized video as an even number

### DIFF
--- a/video_cli/cli/resize.py
+++ b/video_cli/cli/resize.py
@@ -19,8 +19,8 @@ def resize(in_file, scale=1):
     width, height = None, None
     if scale:
         width, height = meta["size"]
-        width = int(round(scale * width))
-        height = int(round(scale * height))
+        width = int(round(scale * width) // 2 * 2)
+        height = int(round(scale * height) // 2 * 2)
 
     macro_block_size = get_macro_block_size((height, width))
 


### PR DESCRIPTION
In this pull request, I set height and width of resized video as an even number.

Without this pull request, error sometime occurs during `video-resize`
For example,
```bash
pip install video-cli
cd /tmp
git clone https://github.com/wkentaro/video-cli.git
cd video-cli/data
video-resize 2018-11-02_14-44-14.mp4 --scale 0.20
```
returns
```
  1%|▎                                                               | 1/185 [00:00<00:24,  7.48it/s][libx264 @ 0x558283989520] height not divisible by 2 (672x411)
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
  1%|▎                                                               | 1/185 [00:00<00:41,  4.47it/s]
Traceback (most recent call last):
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/imageio_ffmpeg/_io.py", line 479, in write_frames
    p.stdin.write(bb)
BrokenPipeError: [Errno 32] Broken pipe

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/naoya/.local/bin/video-resize", line 11, in <module>
    load_entry_point('video-cli', 'console_scripts', 'video-resize')()
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/video_cli/cli/resize.py", line 53, in main
    in_file=in_file, scale=args.scale,
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/video_cli/cli/resize.py", line 37, in resize
    writer.append_data(frame)
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/imageio/core/format.py", line 502, in append_data
    return self._append_data(im, total_meta)
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/imageio/plugins/ffmpeg.py", line 572, in _append_data
    self._write_gen.send(im)
  File "/home/naoya/.pyenv/versions/anaconda3-4.3.1/envs/python3.5/lib/python3.5/site-packages/imageio_ffmpeg/_io.py", line 486, in write_frames
    raise IOError(msg)
OSError: [Errno 32] Broken pipe

FFMPEG COMMAND:
ffmpeg -y -f rawvideo -vcodec rawvideo -s 672x411 -pix_fmt rgb24 -r 15.00 -i - -an -vcodec libx264 -pix_fmt yuv420p -crf 25 -v warning /tmp/video-cli/data/2018-11-02_14-44-14_resize0.2.mp4

FFMPEG STDERR OUTPUT:
```

my ffmpeg environment:
```bash
$ ffmpeg -version
ffmpeg version 3.4.6-0ubuntu0.18.04.1 Copyright (c) 2000-2019 the FFmpeg developers
built with gcc 7 (Ubuntu 7.3.0-16ubuntu3)
configuration: --prefix=/usr --extra-version=0ubuntu0.18.04.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --enable-gpl --disable-stripping --enable-avresample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librubberband --enable-librsvg --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-omx --enable-openal --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libopencv --enable-libx264 --enable-shared
libavutil      55. 78.100 / 55. 78.100
libavcodec     57.107.100 / 57.107.100
libavformat    57. 83.100 / 57. 83.100
libavdevice    57. 10.100 / 57. 10.100
libavfilter     6.107.100 /  6.107.100
libavresample   3.  7.  0 /  3.  7.  0
libswscale      4.  8.100 /  4.  8.100
libswresample   2.  9.100 /  2.  9.100
libpostproc    54.  7.100 / 54.  7.100
```